### PR TITLE
Timeout for long polling

### DIFF
--- a/telegram_bot
+++ b/telegram_bot
@@ -6,6 +6,7 @@ source /root/variables
 
 curl -k -s -X POST $api/sendMessage -d chat_id=$my_chat_id -d parse_mode=Markdown --data-urlencode text="Router started." &> $telegram_log_file
 
+polling_timeout=30
 offset=0
 if [ -f "$offset_file" ] ; then
 	offset=$( cat $offset_file )
@@ -22,7 +23,7 @@ reply_to_msg () {
 
 while [ true ]
 do
-	updates=$(curl -s -k -X GET $api/getUpdates?offset=$offset)
+	updates=$(curl -s -k -X GET ${api}/getUpdates?offset=${offset}&timeout=${polling_timeout})
 	status=$(jsonfilter -s "$updates" -e $.ok)
 	if [ $status = 'true' ]; then
 		update_ids=$(jsonfilter -s "$updates" -e $.result[*].update_id)


### PR DESCRIPTION
Added timeout for long polling, because of Telegram API requirements:
Timeout should be positive, short polling should be used for testing purposes only.
https://core.telegram.org/bots/api#getting-updates